### PR TITLE
Check mob group

### DIFF
--- a/src/main/java/xyz/kadr/yoko/DPSCommand.java
+++ b/src/main/java/xyz/kadr/yoko/DPSCommand.java
@@ -92,6 +92,7 @@ public final class DPSCommand implements CommandHandler {
 
             // Define meta monster
             SceneGroup mobSG = new SceneGroup(); // Mobs scene group
+            mobSG.id = 50505051;
             Map<Integer, SceneMonster> metaMonsters = new HashMap<>(); // Meta monsters
             SceneMonster monster = new SceneMonster();
             metaMonsters.put(param.entityCount, monster);

--- a/src/main/java/xyz/kadr/yoko/EventListener.java
+++ b/src/main/java/xyz/kadr/yoko/EventListener.java
@@ -9,7 +9,7 @@ public final class EventListener {
     public static void EntityDeathEvent(EntityDeathEvent event) {
         GameEntity monster = event.getEntity();
         var entType = event.getEntity().getEntityType();
-        if (EntityType.Monster.getValue() == entType.getValue()){
+        if (EntityType.Monster.getValue() == entType.getValue() && event.getEntity().getGroupId() == 50505051){
             DPSCommand.DPSChallenge.onMonsterDeath((EntityMonster) monster);
         }
 


### PR DESCRIPTION
Check mob group at the listener to prevent onDeath triggering always and breaking other challenges in the world. 
This is important as otherwise the onDeath will fire for all mobs regardless of what challenge they belong to, causing issues. This will ensure the group is checked beforehand, so only the mobs from the spawned challenge can trigger onDeath for the challenge.